### PR TITLE
Fix mobile in dark mode

### DIFF
--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -258,4 +258,7 @@ export default {
       width 5px
       margin -3px 3px 0
       vertical-align middle
+    div[data-ds-theme="dark"]
+      .docs-searchbar-suggestion--subcategory-column
+        background transparent !important
 </style>


### PR DESCRIPTION
## What's wrong ? 

Dark mode in mobile is broken

## What's inside this PR ? 

A color change on the correct class in mobile, with an `!important` to override the light mode's `!important` 🙄

## Screenshots

Before:
![before](https://user-images.githubusercontent.com/30866152/124778818-8dcfb480-df41-11eb-8a47-a42c90bbb457.png)


After:
![after](https://user-images.githubusercontent.com/30866152/124778830-90caa500-df41-11eb-8599-b74972fcab02.png)
