### PR TITLE
Update enableDarkMode to auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ module.exports = {
         cropLength: 50, // Default: 30
         layout: 'simple', // Default: "columns"
         debug: true, // Default: false
-        enableDarkMode: true // Default: false
+        enableDarkMode: 'auto' // Default: false
       }
     ]
   ]
@@ -122,7 +122,7 @@ module.exports = {
 
 #### Dark mode
 
-You can enable dark mode by adding `enableDarkMode: true` to your configuration file.
+You can enable dark mode by adding `enableDarkMode: 'auto'` to your configuration file.
 
 To override the default theme of the search bar, you can edit your `.vuepress/styles/palette.styl` file.<br>
 A few variables are available:

--- a/playground/.vuepress/config.js
+++ b/playground/.vuepress/config.js
@@ -18,7 +18,7 @@ module.exports = {
           'masterKey',
         indexUid: 'docs',
         debug: true,
-        enableDarkMode: true
+        enableDarkMode: 'auto'
         // "maxSuggestions": 10,
         // placeholder: 'Search as you type...'
       }


### PR DESCRIPTION
## Problem

`enableDarkMode` is still in `true`, causing the dark mode to be displayed even if the system is in light mode.

## Solution

Set `enableDarkMode` to `auto` to let the system decide which theme to display