### PR TITLE
fix: include `assets/search.svg` in npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,7 @@ scripts
 .github
 tests
 jest.config.js
-assets
+assets/docs-searchbar-demo.gif
 playground
 babel.config.js
 bors.toml


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes `asset/search.svg` being [excluded](https://github.com/meilisearch/vuepress-plugin-meilisearch/commit/a21976176a9fac83031d6025ec688ee38cc80798) from npm release.
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

### Steps to reproduce

1. Follow the official [guide](https://docs.meilisearch.com/learn/cookbooks/search_bar_for_docs.html#for-vuepress-documentation-sites) to add the plugin
2. Run `yarn docs:build`
3. Expect the following error messages
```bash
(undefined) ./node_modules/vuepress-plugin-meilisearch/MeiliSearchBox.vue?vue&type=style&index=0&id=512bb40d&prod&lang=stylus& (./node_modules/mini-css-extract-plugin/dist/loader.js!./node_modules/css-loader/dist/cjs.js??ref--13-oneOf-1-1!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/postcss-loader/src??ref--13-oneOf-1-2!./node_modules/stylus-loader??ref--13-oneOf-1-3!./node_modules/cache-loader/dist/cjs.js??ref--0-0!./node_modules/vue-loader/lib??vue-loader-options!./node_modules/vuepress-plugin-meilisearch/MeiliSearchBox.vue?vue&type=style&index=0&id=512bb40d&prod&lang=stylus&)
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleNotFoundError: Module not found: Error: Can't resolve './assets/search.svg'
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
