### PR TITLE
Update version for the next release (v0.12.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-plugin-meilisearch",
-  "version": "0.12.3",
+  "version": "0.12.4",
   "description": "Relevant and typo tolerant search bar for your Vuepress",
   "author": "Clémentine Urquizar <clementine@meilisearch.com>",
   "scripts": {


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.29.0 :tada:
Check out the changelog of [Meilisearch v0.29.0](https://github.com/meilisearch/meilisearch/releases/tag/v0.29.0) for more information on the changes.
