### PR TITLE
fix: change input selector to id

### DIFF
--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -82,7 +82,13 @@ export default {
     },
 
     updateTheme(options) {
-      this.theme = options.enableDarkMode === true ? 'dark' : options.enableDarkMode === false ? 'light' : 'auto'
+      if (options.enableDarkMode === true) {
+        this.theme = 'dark'
+      } else if (options.enableDarkMode === false) {
+        this.theme = 'light'
+      } else {
+        this.theme = 'auto'
+      }
     }
   }
 }

--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -3,6 +3,7 @@
     id="search-form"
     class="meilisearch-search-wrapper search-box"
     role="search"
+    :class="'theme-' + theme"
   >
     <input
       id="meilisearch-search-input"
@@ -17,6 +18,7 @@ export default {
   name: 'MeiliSearchBox',
   data() {
     return {
+      theme: false,
       placeholder: undefined
     }
   },
@@ -43,6 +45,7 @@ export default {
       debug: DEBUG,
       enableDarkMode: ENABLE_DARK_MODE
     }
+    this.updateTheme(options)
     this.initialize(options)
     this.placeholder =
       PLACEHOLDER || this.$site.themeConfig.searchPlaceholder || ''
@@ -72,9 +75,14 @@ export default {
     },
 
     update(options) {
+      this.updateTheme(options)
       this.$el.innerHTML =
         '<input id="meilisearch-search-input" class="search-query">'
       this.initialize(options)
+    },
+
+    updateTheme(options) {
+      this.theme = options.enableDarkMode === true ? 'dark' : options.enableDarkMode === false ? 'light' : 'auto'
     }
   }
 }
@@ -82,6 +90,55 @@ export default {
 
 <style lang="stylus">
 @require './styles/palette.styl'
+
+light-input()
+  color lighten($textColor, 25%)
+  border 1px solid darken($borderColor, 10%)
+  background-color #fff
+  &:focus
+    border-color $accentColor
+
+dark-input()
+  color $textDarkColor
+  border 1px solid $borderDarkColor
+  background-color $inputDarkBgColor
+  &:focus
+    border-color $accentDarkColor
+
+// Searchbox
+#meilisearch-search-input
+  cursor text
+  width 10rem
+  height: 2rem
+  display inline-block
+  border-radius 2rem
+  font-size 0.9rem
+  line-height 2rem
+  padding 0 0.5rem 0 2rem
+  outline none
+  transition border .2s ease
+  background: url(assets/search.svg) 0.6rem 0.5rem no-repeat
+  &:focus
+    cursor auto
+  background-size 1rem
+
+.meilisearch-search-wrapper.theme-light
+  #meilisearch-search-input
+    light-input()
+
+.meilisearch-search-wrapper.theme-dark
+  #meilisearch-search-input
+    dark-input()
+
+@media (prefers-color-scheme: dark)
+  .meilisearch-search-wrapper.theme-auto
+    #meilisearch-search-input
+      dark-input()
+
+@media (prefers-color-scheme: light)
+  .meilisearch-search-wrapper.theme-auto
+    #meilisearch-search-input
+      light-input()
 
 .meilisearch-search-wrapper
   display: inline-block;
@@ -91,29 +148,9 @@ export default {
     vertical-align middle
   .dsb-cursor
     background rgba($accentColor, 0.05)
-
-  // Searchbox
-  #meilisearch-search-input
-    cursor text
-    width 10rem
-    height: 2rem
-    color lighten($textColor, 25%)
-    display inline-block
-    border 1px solid darken($borderColor, 10%)
-    border-radius 2rem
-    font-size 0.9rem
-    line-height 2rem
-    padding 0 0.5rem 0 2rem
-    outline none
-    transition all .2s ease
-    &:focus
-      cursor auto
-      border-color $accentColor
-    background #fff url(assets/search.svg) 0.6rem 0.5rem no-repeat
-    background-size 1rem
-
   .meilisearch-autocomplete
     line-height: 2
+
     // Layout "columns"
     .docs-searchbar-suggestion:not(.suggestion-layout-simple)
       border-color $borderColor
@@ -177,14 +214,6 @@ export default {
     .meilisearch-autocomplete
       .dsb-dropdown-menu [class^=dsb-dataset-], .docs-searchbar-suggestion
         background $dropdownBgDarkColor
-
-      // Searchbox
-      #meilisearch-search-input
-        color $textDarkColor
-        border 1px solid $borderDarkColor
-        background-color $inputDarkBgColor
-        &:focus
-          border-color $accentDarkColor
 
       // Layout "columns"
       .docs-searchbar-suggestion:not(.suggestion-layout-simple)

--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -91,28 +91,29 @@ export default {
     vertical-align middle
   .dsb-cursor
     background rgba($accentColor, 0.05)
+
+  // Searchbox
+  #meilisearch-search-input
+    cursor text
+    width 10rem
+    height: 2rem
+    color lighten($textColor, 25%)
+    display inline-block
+    border 1px solid darken($borderColor, 10%)
+    border-radius 2rem
+    font-size 0.9rem
+    line-height 2rem
+    padding 0 0.5rem 0 2rem
+    outline none
+    transition all .2s ease
+    &:focus
+      cursor auto
+      border-color $accentColor
+    background #fff url(assets/search.svg) 0.6rem 0.5rem no-repeat
+    background-size 1rem
+
   .meilisearch-autocomplete
     line-height: 2
-    // Searchbox
-    input
-      cursor text
-      width 10rem
-      height: 2rem
-      color lighten($textColor, 25%)
-      display inline-block
-      border 1px solid darken($borderColor, 10%)
-      border-radius 2rem
-      font-size 0.9rem
-      line-height 2rem
-      padding 0 0.5rem 0 2rem
-      outline none
-      transition all .2s ease
-      &:focus
-        cursor auto
-        border-color $accentColor
-      background #fff url(assets/search.svg) 0.6rem 0.5rem no-repeat
-      background-size 1rem
-
     // Layout "columns"
     .docs-searchbar-suggestion:not(.suggestion-layout-simple)
       border-color $borderColor

--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -179,7 +179,7 @@ export default {
         background $dropdownBgDarkColor
 
       // Searchbox
-      input
+      #meilisearch-search-input
         color $textDarkColor
         border 1px solid $borderDarkColor
         background-color $inputDarkBgColor

--- a/tests/MeiliSearchBoxTest.js
+++ b/tests/MeiliSearchBoxTest.js
@@ -14,7 +14,7 @@ describe('MeiliSearchBox', () => {
 
   it('renders default form and input', () => {
     expect(wrapper.html()).toContain(
-      '<form id="search-form" role="search" class="meilisearch-search-wrapper search-box">'
+      '<form id="search-form" role="search" class="meilisearch-search-wrapper search-box theme-light">'
     )
     expect(wrapper.html()).toContain(
       '<input id="meilisearch-search-input" class="search-query" placeholder="">'


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #263

## What does this PR do?
- Change the selector to the input id, therefor applying the styling even before the docs-searchbar.js is initialized.

This does require a change in [meilisearch/documentation](https://github.com/meilisearch/documentation) because this does not handle `@media (prefers-color-scheme: dark)`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
