### PR TITLE
fix: aligned powered by text in search popup

### DIFF
--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -207,8 +207,9 @@ dark-input()
     // Footer
     .docs-searchbar-footer
       display flex 
-      justify-content space-between 
-      align-items center 
+      justify-content flex-end 
+      align-items center
+      column-gap 10px
       .docs-searchbar-footer-logo
         margin-bottom -4px
     .dsb-cursor .docs-searchbar-suggestion--content

--- a/MeiliSearchBox.vue
+++ b/MeiliSearchBox.vue
@@ -206,10 +206,6 @@ dark-input()
 
     // Footer
     .docs-searchbar-footer
-      display flex 
-      justify-content flex-end 
-      align-items center
-      column-gap 10px
       .docs-searchbar-footer-logo
         margin-bottom -4px
     .dsb-cursor .docs-searchbar-suggestion--content


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #269 

## What does this PR do?
- Aligns the search popup's bottom **Powered By** text to the right.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
