### PR TITLE
Deprecate repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,27 +1,24 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "monthly"
-  labels:
-    - 'skip-changelog'
-    - 'dependencies'
-  rebase-strategy: disabled
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    labels:
+      - 'skip-changelog'
+      - 'dependencies'
+    rebase-strategy: disabled
 
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  labels:
-  - skip-changelog
-  - dependencies
-  versioning-strategy: increase
-  rebase-strategy: disabled
-  ignore:
-      - dependency-name: "eslint*"
-      - dependency-name: "babel-eslint"
-      - dependency-name: "@vue/*"
-      - dependency-name: "prettier"
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      time: '04:00'
+    open-pull-requests-limit: 10
+    labels:
+      - skip-changelog
+      - dependencies
+    versioning-strategy: increase
+    rebase-strategy: disabled
+    allow:
+      - dependency-name: 'docs-searchbar.js'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,24 @@
   <img src="https://raw.githubusercontent.com/meilisearch/integration-guides/main/assets/logos/meilisearch_vuepress.svg" alt="Meilisearch-VuePress" width="200" height="200" />
 </p>
 
-<h1 align="center">Meilisearch VuePress</h1>
+<h1 align="center">DEPRECATED - Meilisearch VuePress</h1>
+
+---
+
+🚨 DEPRECATION WARNING 🚨
+
+Dear Community,
+
+We'd like to share some updates regarding the future maintenance of this repository:
+
+Our team is small, and our availability will be reduced in the upcoming times. As such, we decided to deprecate this repository.
+This means we wont be updating the package to be compatible with VuePress v2.
+
+We still accept bug fixes from the community but no more enhancements.
+
+Seeking immediate support? Please join us on our Discord channel.
+
+---
 
 <h4 align="center">
   <a href="https://github.com/meilisearch/meilisearch">Meilisearch</a> |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dear Community,
 We'd like to share some updates regarding the future maintenance of this repository:
 
 Our team is small, and our availability will be reduced in the upcoming times. As such, we decided to deprecate this repository.
-This means we wont be updating the package to be compatible with VuePress v2.
+This means we won't be updating the package to be compatible with VuePress v2.
 
 We still accept bug fixes from the community but no more enhancements.
 


### PR DESCRIPTION
As per the message in the readme: 

```
Dear Community,

We'd like to share some updates regarding the future maintenance of this repository:

Our team is small, and our availability will be reduced in the upcoming times. As such, we decided to deprecate this repository.
This means we wont be updating the package to be compatible with VuePress v2.

We still accept bug fixes from the community but no more enhancements.

Seeking immediate support? Please join us on our Discord channel.
```